### PR TITLE
Add meta robit

### DIFF
--- a/build/conf/bblayers.conf
+++ b/build/conf/bblayers.conf
@@ -7,6 +7,7 @@ BBFILES ?= ""
 
 BBLAYERS ?= " \
   ${TOPDIR}/../meta-raspberrypi/ \
+  ${TOPDIR}/../meta-robit/ \
   ${TOPDIR}/../oe/meta-oe/ \
   ${TOPDIR}/../poky/meta \
   ${TOPDIR}/../poky/meta-poky \

--- a/meta-robit/conf/layer.conf
+++ b/meta-robit/conf/layer.conf
@@ -1,0 +1,11 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "robit"
+BBFILE_PATTERN_robit = "^${LAYERDIR}/"
+BBFILE_PRIORITY_robit = "5"
+LAYERVERSION_robit = "3"

--- a/meta-robit/recipes-core/images/core-image-robit.bb
+++ b/meta-robit/recipes-core/images/core-image-robit.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Robit brain"
+
+IMAGE_INSTALL = "packagegroup-core-boot ${CORE_IMAGE_EXTRA_INSTALL}"
+
+IMAGE_LINGUAS = " "
+
+LICENSE = "MIT"
+
+inherit core-image
+
+IMAGE_ROOTFS_SIZE ?= "8192"
+IMAGE_ROOTFS_EXTRA_SPACE_append = "${@bb.utils.contains("DISTRO_FEATURES", "systemd", " + 4096", "" ,d)}"


### PR DESCRIPTION
This adds a meta-robit layer with a basic image bb file (copied from core-image-minimal in poky), and adds the new layer to our build/conf file.